### PR TITLE
Hero video bg can only be mp4 upload and should have a fallback image.

### DIFF
--- a/src/Collection/Hero.php
+++ b/src/Collection/Hero.php
@@ -326,7 +326,8 @@ class Hero {
 			}
 
 			if ( 'video' === $item['type'] ) {
-				$new_value[ $index ]['video'] = Utils::get_video_embed_url( $item['video'] );
+				$new_value[ $index ]['video'] = 'file' === $field['sub_fields'][2]['type']
+					? $item['video'] : Utils::get_video_embed_url( $item['video'] );
 				$new_value[ $index ]['fallback_image'] = $item['fallback_image'];
 			}
 		}

--- a/src/Collection/Hero.php
+++ b/src/Collection/Hero.php
@@ -7,8 +7,7 @@ use Lean\Elements\Utils;
  *
  * @package Lean\Elements\Collection
  */
-class Hero
-{
+class Hero {
 	const HEADLINE = 'field_5731d08981bb0';
 	const TAGLINE = 'field_5731d0a081bb1';
 	const BACKGROUND = 'field_5750768b22dc7';
@@ -145,7 +144,7 @@ class Hero
 								'max_size' => '',
 								'mime_types' => '',
 							),
-							array (
+							array(
 								'key' => 'field_57c4af53a7950',
 								'label' => 'Video',
 								'name' => 'video',
@@ -161,7 +160,7 @@ class Hero
 										),
 									),
 								),
-								'wrapper' => array (
+								'wrapper' => array(
 									'width' => '',
 									'class' => '',
 									'id' => '',
@@ -172,7 +171,7 @@ class Hero
 								'max_size' => '',
 								'mime_types' => 'mp4',
 							),
-							array (
+							array(
 								'key' => 'field_57c4af53a7951',
 								'label' => 'Fallback Image',
 								'name' => 'fallback_image',
@@ -188,7 +187,7 @@ class Hero
 										),
 									),
 								),
-								'wrapper' => array (
+								'wrapper' => array(
 									'width' => '',
 									'class' => '',
 									'id' => '',

--- a/src/Collection/Hero.php
+++ b/src/Collection/Hero.php
@@ -145,13 +145,13 @@ class Hero
 								'max_size' => '',
 								'mime_types' => '',
 							),
-							array(
-								'key' => 'field_575078219ea44',
+							array (
+								'key' => 'field_57c4af53a7950',
 								'label' => 'Video',
 								'name' => 'video',
-								'type' => 'url',
-								'instructions' => 'The YouTube or Vimeo video url.',
-								'required' => 0,
+								'type' => 'file',
+								'instructions' => 'Upload the background video. MP4 only.',
+								'required' => 1,
 								'conditional_logic' => array(
 									array(
 										array(
@@ -161,13 +161,48 @@ class Hero
 										),
 									),
 								),
-								'wrapper' => array(
+								'wrapper' => array (
 									'width' => '',
 									'class' => '',
 									'id' => '',
 								),
-								'default_value' => '',
-								'placeholder' => 'https://vimeo.com/66966424',
+								'return_format' => 'url',
+								'library' => 'all',
+								'min_size' => '',
+								'max_size' => '',
+								'mime_types' => 'mp4',
+							),
+							array (
+								'key' => 'field_57c4af53a7951',
+								'label' => 'Fallback Image',
+								'name' => 'fallback_image',
+								'type' => 'image',
+								'instructions' => 'Add an image to be used on mobile devices when the video can\'t be loaded',
+								'required' => 1,
+								'conditional_logic' => array(
+									array(
+										array(
+											'field' => 'field_575076d822dc8',
+											'operator' => '==',
+											'value' => 'video',
+										),
+									),
+								),
+								'wrapper' => array (
+									'width' => '',
+									'class' => '',
+									'id' => '',
+								),
+								'return_format' => 'array',
+								'preview_size' => 'thumbnail',
+								'library' => 'all',
+								'min_width' => 3200,
+								'min_height' => 1340,
+								'min_size' => '',
+								'max_width' => '',
+								'max_height' => '',
+								'max_size' => '',
+								'mime_types' => '',
 							),
 						),
 					),
@@ -293,6 +328,7 @@ class Hero
 
 			if ( 'video' === $item['type'] ) {
 				$new_value[ $index ]['video'] = Utils::get_video_embed_url( $item['video'] );
+				$new_value[ $index ]['fallback_image'] = $item['fallback_image'];
 			}
 		}
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)
  Bug fix
- **What is the current behavior?** (You can also link to an open issue
  here)
  Hero bg's are youtube / vimeo videos, however this doesn't work well.
- **What is the new behavior (if this is a feature change)?**
  Use an mp4 upload instead. Include a still image as fallback for mobiles.
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)
  No, others should carry on working. However, in the future they won't be able to use a youtube/vimeo video.
- **Other information**:
